### PR TITLE
Fixed a bug where only the resource for the first axis is released.

### DIFF
--- a/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Actor/RaymarchVolume.cpp
+++ b/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Actor/RaymarchVolume.cpp
@@ -761,23 +761,11 @@ void ARaymarchVolume::FreeRaymarchResources()
 	}
 	RaymarchResources.LightVolumeTextureRef = nullptr;
 
-	for (int i = 0; i < 3; i++)
+	for (OneAxisReadWriteBufferResources& Buffer : RaymarchResources.XYZReadWriteBuffers)
 	{
-		for (int j = 0; j < 4; j++)
-		{
-			if (RaymarchResources.XYZReadWriteBuffers->UAVs[j])
-			{
-				RaymarchResources.XYZReadWriteBuffers->UAVs[j].SafeRelease();
-			}
-			RaymarchResources.XYZReadWriteBuffers->UAVs[j] = nullptr;
-
-			if (RaymarchResources.XYZReadWriteBuffers->Buffers[j])
-			{
-				RaymarchResources.XYZReadWriteBuffers->Buffers[j].SafeRelease();
-			}
-			RaymarchResources.XYZReadWriteBuffers->Buffers[j] = nullptr;
-		}
+		URaymarchUtils::ReleaseOneAxisReadWriteBufferResources(Buffer);
 	}
+
 	RaymarchResources.bIsInitialized = false;
 }
 

--- a/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Util/RaymarchUtils.cpp
+++ b/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Util/RaymarchUtils.cpp
@@ -184,6 +184,27 @@ void URaymarchUtils::CreateBufferTextures(FIntPoint Size, EPixelFormat PixelForm
 	}
 }
 
+void URaymarchUtils::ReleaseOneAxisReadWriteBufferResources(OneAxisReadWriteBufferResources& Buffer)
+{
+	for (FUnorderedAccessViewRHIRef& UAV : Buffer.UAVs)
+	{
+		if (UAV)
+		{
+			UAV.SafeRelease();
+		}
+		UAV = nullptr;
+	}
+
+	for (FTexture2DRHIRef& TextureRef : Buffer.Buffers)
+	{
+		if (TextureRef)
+		{
+			TextureRef.SafeRelease();
+		}
+		TextureRef = nullptr;
+	}
+}
+
 void URaymarchUtils::GetVolumeTextureDimensions(UVolumeTexture* Texture, FIntVector& Dimensions)
 {
 	if (Texture)

--- a/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h
+++ b/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h
@@ -91,6 +91,8 @@ public:
 	static RAYMARCHER_API void CreateBufferTextures(
 		FIntPoint Size, EPixelFormat PixelFormat, OneAxisReadWriteBufferResources& RWBuffers);
 
+	static RAYMARCHER_API void ReleaseOneAxisReadWriteBufferResources(OneAxisReadWriteBufferResources& Buffer);
+
 	// UFUNCTION(BlueprintCallable, Category = "Raymarcher")
 	// static RAYMARCHER_API void UpdateVolumeTextureSource(UVolumeTexture* Texture);
 


### PR DESCRIPTION
This commit attempts to address a bug where FreeRaymarchResources is not correctly releasing memory for resources regarding all three axes. The bug was caused by releasing the resource for the first axis thrice other and that the progression index i was not used.