### PR TITLE
Add Linux build documentation and update plugin submodule

### DIFF
--- a/Documents/Notes/LinuxBuildNotes.md
+++ b/Documents/Notes/LinuxBuildNotes.md
@@ -1,0 +1,142 @@
+# Linux Build Notes
+
+## Engine
+- Unreal Engine 5.4 built from source at `/opt/unreal-engine-5.4.0/`
+- Linux only supports Vulkan (no OpenGL backend)
+
+## Build Command
+```bash
+/opt/unreal-engine-5.4.0/Engine/Build/BatchFiles/Linux/Build.sh \
+  TBRaymarchProjectEditor Linux Development \
+  -Project="/path/to/TBRaymarchProject.uproject"
+```
+
+## DCMTK 3.6.8 — Rebuilding Static Libraries for Linux
+
+The plugin bundles DCMTK as static libraries. The Windows `.lib` files are
+checked in; the Linux `.a` files must be built with specific flags to be
+ABI-compatible with UE5's toolchain.
+
+### Prerequisites
+- System `clang` and `clang++` (not UE5's bundled clang — see below)
+- `libc++` and `libc++abi` development packages (`libc++-dev`, `libc++abi-dev` or equivalent)
+- DCMTK 3.6.8 source
+
+### Why not use UE5's bundled clang as a cross-compiler?
+DCMTK's cmake build uses `try_run()` for arithmetic type detection (`arith.h`
+generation). Cross-compiling with UE5's toolchain breaks these runtime checks
+because the executables target UE5's CentOS 7 sysroot, which may not run on the
+host. Using the system clang with `-stdlib=libc++` produces ABI-compatible
+objects without the cross-compilation issues.
+
+### CMake Configure
+```bash
+cmake <dcmtk-3.6.8-source> \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DDCMTK_ENABLE_PRIVATE_TAGS=OFF \
+  -DDCMTK_WITH_ZLIB=OFF -DDCMTK_WITH_PNG=OFF -DDCMTK_WITH_TIFF=OFF \
+  -DDCMTK_WITH_XML=OFF -DDCMTK_WITH_ICONV=OFF -DDCMTK_WITH_ICU=OFF \
+  -DDCMTK_WITH_OPENSSL=OFF -DDCMTK_WITH_SNDFILE=OFF -DDCMTK_WITH_WRAP=OFF \
+  -DDCMTK_WITH_DOXYGEN=OFF -DDCMTK_WITH_OPENJPEG=OFF \
+  -DDCMTK_ENABLE_CHARSET_CONVERSION=OFF \
+  -DBUILD_APPS=OFF \
+  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DCMAKE_CXX_FLAGS="-fPIC -stdlib=libc++" \
+  -DCMAKE_C_FLAGS="-fPIC -std=gnu17" \
+  -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
+  -DHAVE_STRLCPY=FALSE \
+  -DHAVE_STRLCAT=FALSE
+```
+
+Key flags explained:
+- **`-stdlib=libc++`**: UE5 uses libc++, not libstdc++. Mixing ABIs causes linker errors.
+- **`-DHAVE_STRLCPY=FALSE -DHAVE_STRLCAT=FALSE`**: Newer glibc provides these, but
+  UE5's CentOS 7 sysroot does not. Force DCMTK to use its internal fallbacks.
+- **`-DDCMTK_ENABLE_CHARSET_CONVERSION=OFF`**: Disables iconv dependency. The generated
+  `osconfig_linux.h` must then have `DCMTK_ENABLE_CHARSET_CONVERSION` manually set to
+  `DCMTK_CHARSET_CONVERSION_OFICONV` to avoid an `-Wundef` error.
+
+### Post-build Steps
+
+1. Copy these `.a` files to `Plugins/.../ThirdParty/dcmtk/lib/Linux/`:
+   ```
+   libdcmjpls.a  libdcmjpeg.a  libdcmimage.a  libdcmimgle.a
+   libdcmdata.a  liboflog.a    libofstd.a     liboficonv.a
+   libdcmtkcharls.a  libijg8.a  libijg12.a  libijg16.a
+   ```
+
+2. Copy generated headers to `ThirdParty/dcmtk/include/dcmtk/config/`:
+   - `osconfig.h` → `osconfig_linux.h`
+   - `arith.h` → `arith_linux.h`
+
+3. Patch `osconfig_linux.h`: add or change:
+   ```c
+   #define DCMTK_ENABLE_CHARSET_CONVERSION DCMTK_CHARSET_CONVERSION_OFICONV
+   ```
+
+4. The dispatcher headers (`osconfig.h`, `arith.h`) already `#include` the
+   `*_linux.h` or `*_win64.h` variant based on platform — no changes needed there.
+
+### glibc C23 Compatibility Shim (`libisoc23_compat.a`)
+
+On glibc 2.38+, when `_DEFAULT_SOURCE` is defined (which DCMTK sets internally),
+the C library redirects standard functions to C23 versions:
+- `sscanf` → `__isoc23_sscanf`
+- `strtol` → `__isoc23_strtol`
+
+These symbols are baked into the DCMTK `.a` files at compile time. UE5's CentOS 7
+sysroot doesn't have them, causing unresolved symbol errors at link time.
+
+**Fix**: A small shim library that forwards these back to the standard versions:
+
+```c
+// isoc23_compat.c
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+int __isoc23_sscanf(const char *str, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int ret = vsscanf(str, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+long __isoc23_strtol(const char *nptr, char **endptr, int base) {
+    return strtol(nptr, endptr, base);
+}
+```
+
+Build **without** `_DEFAULT_SOURCE` to avoid the same redirect:
+```bash
+clang -std=c17 -fPIC -c isoc23_compat.c -o isoc23_compat.o
+ar rcs libisoc23_compat.a isoc23_compat.o
+```
+
+Copy `libisoc23_compat.a` to `ThirdParty/dcmtk/lib/Linux/`. It is already
+referenced in `VolumeTextureToolkit.Build.cs`.
+
+## Vulkan Shader Parameter API
+
+UE 5.3 deprecated the per-call `SetShaderValue(RHICmdList, ShaderRHI, ...)`
+and `SetTextureParameter(RHICmdList, ShaderRHI, ...)` APIs. On Vulkan, these
+cause null `FRHITexture*` crashes in `RHISetShaderTexture`.
+
+Use the batched API instead:
+```cpp
+FRHIBatchedShaderParameters& Params = RHICmdList.GetScratchShaderParameters();
+SetShaderValue(Params, MyParam, Value);
+SetTextureParameter(Params, MyTexture, TextureRHI);
+SetSamplerParameter(Params, MySampler, SamplerStateRHI);
+SetUAVParameter(Params, MyUAV, UAVRef);
+RHICmdList.SetBatchedShaderParameters(ShaderRHI, Params);
+```
+
+Do **not** unbind resources by setting them to `nullptr` through the batched API
+— Vulkan will dereference the null pointer. Resource transitions
+(`RHICmdList.Transition()`) handle state management on Vulkan/D3D12.

--- a/logs/build.log
+++ b/logs/build.log
@@ -1,0 +1,629 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Creating makefile for TBRaymarchProjectEditor (no existing makefile)
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/oficonv.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/ofstd.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/oflog.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/dcmdata.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/ijg8.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/ijg12.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/ijg16.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/dcmimgle.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/dcmimage.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/dcmjpeg.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/dcmtkcharls.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Library '/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/dcmjpls.lib' was not resolvable to a file when used in Module 'VolumeTextureToolkit', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning. 
+Parsing headers for TBRaymarchProjectEditor
+  Running Internal UnrealHeaderTool "/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject" "/home/ruby/Unreal Projects/TBRaymarchProject/Intermediate/Build/Linux/TBRaymarchProjectEditor/Development/TBRaymarchProjectEditor.uhtmanifest" -WarningsAsErrors -installed
+Total of 72 written
+Reflection code generated for TBRaymarchProjectEditor in 1.2993688 seconds
+------- Build details --------
+Using toolchain located at '/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu'.
+Using clang (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/clang++) version 'clang version 16.0.6 (github.com/llvm/llvm-project 7cbf1a2591520c2491aa35339f227775f4d3adf6)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin' (string), 16 (major), 0 (minor), 6 (patch)
+Using bundled libc++ standard C++ library.
+Using lld linker
+Using llvm-ar (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/llvm-ar) version 'LLVM (http://llvm.org/):
+  LLVM version 16.0.6
+  Optimized build. (string)'
+Using fast way to relink  circularly dependent libraries (no FixDeps).
+Targeted minimum CPU architecture: None
+------------------------------
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 20 action(s)
+------ Building 20 action(s) started ------
+[1/20] Compile SharedPCH.Engine.Project.ValApi.Cpp20.h
+[2/20] Compile SharedPCH.Engine.Project.ValApi.Cpp17.h
+[3/20] Compile Module.Tests.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Tests/Module.Tests.cpp:2:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Tests/UHT/PerformanceTest1.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Tests/Public/Actor/PerformanceTest1.h:6:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Actor/RaymarchVolume.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/VolumeAsset.h:13:10: fatal error: 'VolumeAsset.Generated.h' file not found
+#include "VolumeAsset.Generated.h"
+         ^~~~~~~~~~~~~~~~~~~~~~~~~
+1 error generated.
+[4/20] Compile TBRaymarchProjectGameModeBase.cpp
+[5/20] Compile TBRaymarchProject.cpp
+[6/20] Compile TBRaymarchProject.init.gen.cpp
+[7/20] Compile TBRaymarchProjectGameModeBase.gen.cpp
+[8/20] Link (lld) libUnrealEditor-TBRaymarchProject.so
+[9/20] Compile Module.RayUtils.cpp
+[10/20] Link (lld) libUnrealEditor-RayUtils.so
+[11/20] Compile Module.VolumeTextureToolkitEditor.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkitEditor/Module.VolumeTextureToolkitEditor.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkitEditor/Private/VolumeAssetFactory.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/Loaders/DCMTKLoader.h:5:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/Loaders/VolumeLoader.h:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/VolumeAsset.h:13:10: fatal error: 'VolumeAsset.Generated.h' file not found
+#include "VolumeAsset.Generated.h"
+         ^~~~~~~~~~~~~~~~~~~~~~~~~
+1 error generated.
+[12/20] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:2:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/VolumeTextureToolkit/UHT/DCMTKLoader.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/Loaders/DCMTKLoader.h:5:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/Loaders/VolumeLoader.h:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/VolumeAsset.h:13:10: fatal error: 'VolumeAsset.Generated.h' file not found
+#include "VolumeAsset.Generated.h"
+         ^~~~~~~~~~~~~~~~~~~~~~~~~
+1 error generated.
+[13/20] Compile Module.Raymarcher.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:73:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, bAdded, bLightAdded ? 1 : -1);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:100:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingCenter, FVector3f(LocalClippingParams.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:101:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingDirection, FVector3f(LocalClippingParams.Direction));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:102:3: warning: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, WindowingParameters, pWindowingParameters);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:109:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:118:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:120:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:128:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, pALightVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:133:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PermutationMatrix, FMatrix44f(PermMatrix));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:138:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:139:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, TransferFunc, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:146:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:147:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:148:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, ReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:154:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PrevPixelOffset, fPixelOffset);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:160:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, UVWOffset, fUVWOffset);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:258:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:260:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:273:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, RemovedWriteBuffer, pRemovedWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:284:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:286:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:294:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, pALightVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:299:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PermutationMatrix, FMatrix44f(PermMatrix));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:305:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PrevPixelOffset, FVector2f(AddedPixelOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:306:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedPrevPixelOffset, FVector2f(RemovedPixelOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:312:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, UVWOffset, FVector3f(pAddedUVWOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:313:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedUVWOffset, FVector3f(pRemovedUVWOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:319:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pAddedStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:320:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedStepSize, pRemovedStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:325:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:326:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, TransferFunc, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:333:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:334:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:335:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, ReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:342:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, RemovedWriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:343:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, RemovedReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:370:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingCenter, FVector3f(LocalClippingParams.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:371:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingDirection, FVector3f(LocalClippingParams.Direction));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:372:3: warning: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, WindowingParameters, pWindowingParameters);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:379:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:10:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchVolume.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Actor/RaymarchVolume.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/VolumeAsset.h:13:10: fatal error: 'VolumeAsset.Generated.h' file not found
+#include "VolumeAsset.Generated.h"
+         ^~~~~~~~~~~~~~~~~~~~~~~~~
+40 warnings and 1 error generated.
+[14/20] Compile Module.FractalMarcher.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:83:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, MandelbulbVolumeUAV, Parameters.MandelbulbVolumeUAVRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:84:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, MandelbulbVolumeDimensions, FVector3f(Parameters.MandelbulbVolumeDimensions));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:86:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Center, FVector3f(Parameters.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:87:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Extent, FVector3f(Parameters.Extent));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:88:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Power, Parameters.Power);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:10:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Private/Actor/FractalVolume.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/TextureUtilities.h:22:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/VolumeAsset/VolumeAsset.h:13:10: fatal error: 'VolumeAsset.Generated.h' file not found
+#include "VolumeAsset.Generated.h"
+         ^~~~~~~~~~~~~~~~~~~~~~~~~
+5 warnings and 1 error generated.
+Total time in Parallel executor: 20.55 seconds
+Total execution time: 24.84 seconds

--- a/logs/build10.log
+++ b/logs/build10.log
@@ -1,0 +1,126 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 7 action(s)
+------ Building 7 action(s) started ------
+[1/7] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+7 warnings generated.
+[2/7] Link (lld) libUnrealEditor-VolumeTextureToolkit.so
+ld.lld: error: undefined symbol: strlcpy
+>>> referenced by dcdicent.cc
+>>>               dcdicent.cc.o:(DcmDictEntry::DcmDictEntry(unsigned short, unsigned short, DcmVR, char const*, int, int, char const*, bool, char const*)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmdata.a
+>>> referenced by dcdict.cc
+>>>               dcdict.cc.o:(DcmDataDictionary::loadExternalDictionaries()) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmdata.a
+>>> referenced by dcdict.cc
+>>>               dcdict.cc.o:(DcmDataDictionary::loadDictionary(char const*, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmdata.a
+>>> referenced 33 more times
+>>> did you mean: strncpy
+>>> defined in: ../Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/lib64/libc.so.6
+ld.lld: error: undefined symbol: __isoc23_sscanf
+>>> referenced by dcdict.cc
+>>>               dcdict.cc.o:(DcmDataDictionary::loadDictionary(char const*, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmdata.a
+>>> referenced by dcdict.cc
+>>>               dcdict.cc.o:(DcmDataDictionary::loadDictionary(char const*, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmdata.a
+>>> referenced by dcdict.cc
+>>>               dcdict.cc.o:(DcmDataDictionary::loadDictionary(char const*, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmdata.a
+>>> referenced 35 more times
+ld.lld: error: undefined symbol: strlcat
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::combineDirAndFilename(OFFilename&, OFFilename const&, OFFilename const&, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::getISOFormattedTime(OFString&, bool, bool, bool, bool, OFString const&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::getISOFormattedTime(OFString&, bool, bool, bool, bool, OFString const&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 5 more times
+ld.lld: error: undefined symbol: __isoc23_strtol
+>>> referenced by patlay.cc
+>>>               patlay.cc.o:(dcmtk::log4cplus::pattern::PatternParser::extractPrecisionOption()) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced by patlay.cc
+>>>               patlay.cc.o:(dcmtk::log4cplus::pattern::PatternParser::finalizeConverter(char)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced by fileap.cc
+>>>               fileap.cc.o:(dcmtk::log4cplus::RollingFileAppender::RollingFileAppender(dcmtk::log4cplus::helpers::Properties const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced 1 more times
+clang++: error: linker command failed with exit code 1 (use -v to see invocation)
+Total time in Parallel executor: 5.68 seconds
+Total execution time: 6.37 seconds

--- a/logs/build11.log
+++ b/logs/build11.log
@@ -1,0 +1,108 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 7 action(s)
+------ Building 7 action(s) started ------
+[1/7] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+7 warnings generated.
+[2/7] Link (lld) libUnrealEditor-VolumeTextureToolkit.so
+ld.lld: error: undefined symbol: __isoc23_sscanf
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::setISOFormattedTime(OFString const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::setISOFormattedTime(OFString const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::setISOFormattedTime(OFString const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 35 more times
+ld.lld: error: undefined symbol: __isoc23_strtol
+>>> referenced by patlay.cc
+>>>               patlay.cc.o:(dcmtk::log4cplus::pattern::PatternParser::extractPrecisionOption()) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced by patlay.cc
+>>>               patlay.cc.o:(dcmtk::log4cplus::pattern::PatternParser::finalizeConverter(char)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced by fileap.cc
+>>>               fileap.cc.o:(dcmtk::log4cplus::RollingFileAppender::RollingFileAppender(dcmtk::log4cplus::helpers::Properties const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced 1 more times
+clang++: error: linker command failed with exit code 1 (use -v to see invocation)
+Total time in Parallel executor: 15.40 seconds
+Total execution time: 17.00 seconds

--- a/logs/build12.log
+++ b/logs/build12.log
@@ -1,0 +1,36 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Invalidating makefile for TBRaymarchProjectEditor (VolumeTextureToolkit.Build.cs modified)
+Parsing headers for TBRaymarchProjectEditor
+  Running Internal UnrealHeaderTool "/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject" "/home/ruby/Unreal Projects/TBRaymarchProject/Intermediate/Build/Linux/TBRaymarchProjectEditor/Development/TBRaymarchProjectEditor.uhtmanifest" -WarningsAsErrors -installed
+Total of 0 written
+Reflection code generated for TBRaymarchProjectEditor in 3.0776684 seconds
+------- Build details --------
+Using toolchain located at '/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu'.
+Using clang (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/clang++) version 'clang version 16.0.6 (github.com/llvm/llvm-project 7cbf1a2591520c2491aa35339f227775f4d3adf6)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin' (string), 16 (major), 0 (minor), 6 (patch)
+Using bundled libc++ standard C++ library.
+Using lld linker
+Using llvm-ar (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/llvm-ar) version 'LLVM (http://llvm.org/):
+  LLVM version 16.0.6
+  Optimized build. (string)'
+Using fast way to relink  circularly dependent libraries (no FixDeps).
+Targeted minimum CPU architecture: None
+------------------------------
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 6 action(s)
+------ Building 6 action(s) started ------
+[1/6] Link (lld) libUnrealEditor-VolumeTextureToolkit.so
+[2/6] Link (lld) libUnrealEditor-FractalMarcher.so
+[3/6] Link (lld) libUnrealEditor-Raymarcher.so
+[4/6] Link (lld) libUnrealEditor-VolumeTextureToolkitEditor.so
+[5/6] Link (lld) libUnrealEditor-Tests.so
+[6/6] WriteMetadata TBRaymarchProjectEditor.target
+Total time in Parallel executor: 0.84 seconds
+Total execution time: 9.70 seconds

--- a/logs/build13.log
+++ b/logs/build13.log
@@ -1,0 +1,91 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 2 action(s)
+------ Building 2 action(s) started ------
+[1/2] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+7 warnings generated.
+[2/2] Link (lld) libUnrealEditor-VolumeTextureToolkit.so
+Total time in Parallel executor: 5.67 seconds
+Total execution time: 6.36 seconds

--- a/logs/build2.log
+++ b/logs/build2.log
@@ -1,0 +1,960 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Invalidating makefile for TBRaymarchProjectEditor (VolumeTextureToolkit.Build.cs modified)
+Parsing headers for TBRaymarchProjectEditor
+  Running Internal UnrealHeaderTool "/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject" "/home/ruby/Unreal Projects/TBRaymarchProject/Intermediate/Build/Linux/TBRaymarchProjectEditor/Development/TBRaymarchProjectEditor.uhtmanifest" -WarningsAsErrors -installed
+Total of 0 written
+Reflection code generated for TBRaymarchProjectEditor in 1.3813932 seconds
+------- Build details --------
+Using toolchain located at '/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu'.
+Using clang (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/clang++) version 'clang version 16.0.6 (github.com/llvm/llvm-project 7cbf1a2591520c2491aa35339f227775f4d3adf6)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin' (string), 16 (major), 0 (minor), 6 (patch)
+Using bundled libc++ standard C++ library.
+Using lld linker
+Using llvm-ar (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/llvm-ar) version 'LLVM (http://llvm.org/):
+  LLVM version 16.0.6
+  Optimized build. (string)'
+Using fast way to relink  circularly dependent libraries (no FixDeps).
+Targeted minimum CPU architecture: None
+------------------------------
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 11 action(s)
+------ Building 11 action(s) started ------
+[1/11] Compile Module.VolumeTextureToolkitEditor.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkitEditor/Module.VolumeTextureToolkitEditor.cpp:4:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkitEditor/Private/VolumeAssetFactory.cpp:45:99: error: variable 'Window' is uninitialized when used within its own initialization [-Werror,-Wuninitialized]
+                        .SupportsMinimize(false)[SAssignNew(VolumeImporterWindow, SVolumeImporterWindow).WidgetWindow(&Window.Get())];
+                                                                                                                       ^~~~~~
+1 error generated.
+[2/11] Compile Module.Tests.cpp
+[3/11] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /usr/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /usr/include/dcmtk/dcmdata/dcitem.h:28:
+In file included from /usr/include/dcmtk/ofstd/offile.h:27:
+In file included from /usr/include/dcmtk/ofstd/oftypes.h:48:
+In file included from ThirdParty/Unix/LibCxx/include/c++/v1/ostream:169:
+In file included from ThirdParty/Unix/LibCxx/include/c++/v1/ios:221:
+In file included from ThirdParty/Unix/LibCxx/include/c++/v1/__locale:17:
+In file included from ThirdParty/Unix/LibCxx/include/c++/v1/locale.h:46:
+In file included from /usr/include/locale.h:135:
+In file included from /usr/include/bits/types/locale_t.h:22:
+/usr/include/bits/types/__locale_t.h:27:8: error: redefinition of '__locale_struct'
+struct __locale_struct
+       ^
+/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/usr/include/xlocale.h:27:16: note: previous definition is here
+typedef struct __locale_struct
+               ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /usr/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /usr/include/dcmtk/dcmdata/dcitem.h:28:
+In file included from /usr/include/dcmtk/ofstd/offile.h:27:
+In file included from /usr/include/dcmtk/ofstd/oftypes.h:49:
+In file included from ThirdParty/Unix/LibCxx/include/c++/v1/cinttypes:240:
+In file included from ThirdParty/Unix/LibCxx/include/c++/v1/inttypes.h:251:
+/usr/include/inttypes.h:168:6: error: function-like macro '__GLIBC_USE' is not defined
+# if __GLIBC_USE (ISOC23)
+     ^
+/usr/include/inttypes.h:306:6: error: function-like macro '__GLIBC_USE' is not defined
+# if __GLIBC_USE (ISOC23)
+     ^
+/usr/include/inttypes.h:354:5: error: function-like macro '__GLIBC_USE' is not defined
+#if __GLIBC_USE (ISOC2Y)
+    ^
+/usr/include/inttypes.h:382:5: error: function-like macro '__GLIBC_USE' is not defined
+#if __GLIBC_USE (C23_STRTOL)
+    ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /usr/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /usr/include/dcmtk/dcmdata/dcitem.h:28:
+In file included from /usr/include/dcmtk/ofstd/offile.h:29:
+/usr/include/dcmtk/ofstd/ofstd.h:118:14: error: no member named 'strlcpy' in the global namespace; did you mean simply 'strlcpy'?
+      return ::strlcpy(dst, src, siz);
+             ^~
+/usr/include/dcmtk/ofstd/ofstd.h:115:26: note: 'strlcpy' declared here
+    static inline size_t strlcpy(char *dst, const char *src, size_t siz)
+                         ^
+/usr/include/dcmtk/ofstd/ofstd.h:144:14: error: no member named 'strlcat' in the global namespace; did you mean simply 'strlcat'?
+      return ::strlcat(dst, src, siz);
+             ^~
+/usr/include/dcmtk/ofstd/ofstd.h:141:26: note: 'strlcat' declared here
+    static inline size_t strlcat(char *dst, const char *src, size_t siz)
+                         ^
+7 warnings and 7 errors generated.
+[4/11] Compile Module.FractalMarcher.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:83:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, MandelbulbVolumeUAV, Parameters.MandelbulbVolumeUAVRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:84:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, MandelbulbVolumeDimensions, FVector3f(Parameters.MandelbulbVolumeDimensions));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:86:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Center, FVector3f(Parameters.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:87:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Extent, FVector3f(Parameters.Extent));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:88:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Power, Parameters.Power);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:10:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Private/Actor/FractalVolume.cpp:191:3: warning: 'RHICreateUnorderedAccessView' is deprecated: RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                RHICreateUnorderedAccessView(MandelbulbResources.MandelbulbVolume->GetResource()->TextureRHI);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RHI/Public/RHICommandList.h:5082:1: note: 'RHICreateUnorderedAccessView' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+6 warnings generated.
+[5/11] Compile Module.Raymarcher.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:73:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, bAdded, bLightAdded ? 1 : -1);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:100:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingCenter, FVector3f(LocalClippingParams.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:101:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingDirection, FVector3f(LocalClippingParams.Direction));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:102:3: warning: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, WindowingParameters, pWindowingParameters);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:109:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:118:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:120:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:128:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, pALightVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:133:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PermutationMatrix, FMatrix44f(PermMatrix));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:138:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:139:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, TransferFunc, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:146:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:147:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:148:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, ReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:154:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PrevPixelOffset, fPixelOffset);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:160:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, UVWOffset, fUVWOffset);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:258:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:260:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:273:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, RemovedWriteBuffer, pRemovedWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:284:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:286:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:294:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, pALightVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:299:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PermutationMatrix, FMatrix44f(PermMatrix));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:305:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PrevPixelOffset, FVector2f(AddedPixelOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:306:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedPrevPixelOffset, FVector2f(RemovedPixelOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:312:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, UVWOffset, FVector3f(pAddedUVWOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:313:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedUVWOffset, FVector3f(pRemovedUVWOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:319:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pAddedStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:320:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedStepSize, pRemovedStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:325:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:326:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, TransferFunc, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:333:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:334:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:335:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, ReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:342:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, RemovedWriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:343:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, RemovedReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:370:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingCenter, FVector3f(LocalClippingParams.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:371:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingDirection, FVector3f(LocalClippingParams.Direction));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:372:3: warning: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, WindowingParameters, pWindowingParameters);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:379:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:20:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Actor/RaymarchVolume.cpp:902:5: warning: 'RHICreateUnorderedAccessView' is deprecated: RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                                RHICreateUnorderedAccessView(RaymarchResources.LightVolumeRenderTarget->GetResource()->TextureRHI);
+                                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RHI/Public/RHICommandList.h:5082:1: note: 'RHICreateUnorderedAccessView' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:20:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Actor/RaymarchVolume.cpp:912:5: warning: 'RHICreateUnorderedAccessView' is deprecated: RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                                RHICreateUnorderedAccessView(RaymarchResources.OctreeVolumeRenderTarget->GetResource()->TextureRHI);
+                                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RHI/Public/RHICommandList.h:5082:1: note: 'RHICreateUnorderedAccessView' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:44:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, pVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:45:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume0, ComputeResource->UnorderedAccessViewRHIs[0]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:46:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume1, ComputeResource->UnorderedAccessViewRHIs[1]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:47:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume2, ComputeResource->UnorderedAccessViewRHIs[2]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:48:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume3, ComputeResource->UnorderedAccessViewRHIs[3]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:49:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, MinMaxValues, FVector2f(0.0, 1.0));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:50:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LeafNodeSize, InLeafNodeSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:51:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, NumberOfMips, InNumberOfMips);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:56:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:57:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume0, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:58:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume1, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:59:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume2, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:60:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume3, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+62 warnings generated.
+Total time in Parallel executor: 8.54 seconds
+Total execution time: 12.42 seconds

--- a/logs/build3.log
+++ b/logs/build3.log
@@ -1,0 +1,925 @@
+╭─ …eal-Projects-TBRaymarchProject/5f9e1060-74c7-4bd9-b25e-a861eb332bbd/scratchpad/dcmtk-build/build
+╰──➤ /opt/unreal-engine-5.4.0/Engine/Build/BatchFiles/Linux/Build.sh TBRaymarchProjectEditor Linux Development -Project="/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject"
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Invalidating makefile for TBRaymarchProjectEditor (VolumeTextureToolkit.Build.cs modified)
+Parsing headers for TBRaymarchProjectEditor
+  Running Internal UnrealHeaderTool "/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject" "/home/ruby/Unreal Projects/TBRaymarchProject/Intermediate/Build/Linux/TBRaymarchProjectEditor/Development/TBRaymarchProjectEditor.uhtmanifest" -WarningsAsErrors -installed
+Total of 0 written
+Reflection code generated for TBRaymarchProjectEditor in 1.4246882 seconds
+------- Build details --------
+Using toolchain located at '/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu'.
+Using clang (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/clang++) version 'clang version 16.0.6 (github.com/llvm/llvm-project 7cbf1a2591520c2491aa35339f227775f4d3adf6)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin' (string), 16 (major), 0 (minor), 6 (patch)
+Using bundled libc++ standard C++ library.
+Using lld linker
+Using llvm-ar (/opt/unreal-engine-5.4.0/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/x86_64-unknown-linux-gnu/bin/llvm-ar) version 'LLVM (http://llvm.org/):
+  LLVM version 16.0.6
+  Optimized build. (string)'
+Using fast way to relink  circularly dependent libraries (no FixDeps).
+Targeted minimum CPU architecture: None
+------------------------------
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 11 action(s)
+------ Building 11 action(s) started ------
+[1/11] Compile Module.VolumeTextureToolkitEditor.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkitEditor/Module.VolumeTextureToolkitEditor.cpp:4:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkitEditor/Private/VolumeAssetFactory.cpp:45:99: error: variable 'Window' is uninitialized when used within its own initialization [-Werror,-Wuninitialized]
+                        .SupportsMinimize(false)[SAssignNew(VolumeImporterWindow, SVolumeImporterWindow).WidgetWindow(&Window.Get())];
+                                                                                                                       ^~~~~~
+1 error generated.
+[2/11] Compile Module.Tests.cpp
+[3/11] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcitem.h:29:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dctypes.h:27:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/oflog.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/logger.h:36:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/spi/apndatch.h:33:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/appender.h:33:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofmem.h:43:5: error: '_MSC_VER' is not defined, evaluates to 0 [-Werror,-Wundef]
+#if _MSC_VER <= 1200
+    ^
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofmem.h:247:9: error: unknown type name 'LONG'
+        OF_SHARED_PTR_COUNTER_TYPE m_Count;
+        ^
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofmem.h:44:36: note: expanded from macro 'OF_SHARED_PTR_COUNTER_TYPE'
+#define OF_SHARED_PTR_COUNTER_TYPE LONG
+                                   ^
+7 warnings and 2 errors generated.
+[4/11] Compile Module.FractalMarcher.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:83:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, MandelbulbVolumeUAV, Parameters.MandelbulbVolumeUAVRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:84:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, MandelbulbVolumeDimensions, FVector3f(Parameters.MandelbulbVolumeDimensions));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:86:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Center, FVector3f(Parameters.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:87:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Extent, FVector3f(Parameters.Extent));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:4:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/FractalMarcher/UHT/FractalShaders.gen.cpp:8:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Public/Rendering/FractalShaders.h:88:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Power, Parameters.Power);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/FractalMarcher/Module.FractalMarcher.cpp:10:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/FractalMarcher/Private/Actor/FractalVolume.cpp:191:3: warning: 'RHICreateUnorderedAccessView' is deprecated: RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                RHICreateUnorderedAccessView(MandelbulbResources.MandelbulbVolume->GetResource()->TextureRHI);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RHI/Public/RHICommandList.h:5082:1: note: 'RHICreateUnorderedAccessView' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+6 warnings generated.
+[5/11] Compile Module.Raymarcher.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:73:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, bAdded, bLightAdded ? 1 : -1);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:100:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingCenter, FVector3f(LocalClippingParams.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:101:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingDirection, FVector3f(LocalClippingParams.Direction));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:102:3: warning: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, WindowingParameters, pWindowingParameters);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:109:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:118:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:120:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:128:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, pALightVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:133:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PermutationMatrix, FMatrix44f(PermMatrix));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:138:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:139:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, TransferFunc, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:146:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:147:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:148:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, ReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:154:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PrevPixelOffset, fPixelOffset);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:160:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, UVWOffset, fUVWOffset);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:258:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:260:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:273:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, RemovedWriteBuffer, pRemovedWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:284:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, Loop, loopIndex);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:286:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, pWriteBuffer);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:294:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, pALightVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:299:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PermutationMatrix, FMatrix44f(PermMatrix));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TMatrix<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:305:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, PrevPixelOffset, FVector2f(AddedPixelOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:306:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedPrevPixelOffset, FVector2f(RemovedPixelOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:312:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, UVWOffset, FVector3f(pAddedUVWOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:313:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedUVWOffset, FVector3f(pRemovedUVWOffset));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:319:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pAddedStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:320:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, RemovedStepSize, pRemovedStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:325:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:326:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, TransferFunc, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:333:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, ALightVolume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:334:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, WriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:335:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, ReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:342:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, RemovedWriteBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:343:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, RemovedReadBuffer, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:370:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingCenter, FVector3f(LocalClippingParams.Center));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:371:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LocalClippingDirection, FVector3f(LocalClippingParams.Direction));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:372:3: warning: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, WindowingParameters, pWindowingParameters);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, FLinearColor, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:9:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/UnrealEditor/Inc/Raymarcher/UHT/RaymarchUtils.gen.cpp:8:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Util/RaymarchUtils.h:14:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/LightingShaders.h:379:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, StepSize, pStepSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:20:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Actor/RaymarchVolume.cpp:902:5: warning: 'RHICreateUnorderedAccessView' is deprecated: RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                                RHICreateUnorderedAccessView(RaymarchResources.LightVolumeRenderTarget->GetResource()->TextureRHI);
+                                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RHI/Public/RHICommandList.h:5082:1: note: 'RHICreateUnorderedAccessView' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:20:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Actor/RaymarchVolume.cpp:912:5: warning: 'RHICreateUnorderedAccessView' is deprecated: RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                                RHICreateUnorderedAccessView(RaymarchResources.OctreeVolumeRenderTarget->GetResource()->TextureRHI);
+                                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RHI/Public/RHICommandList.h:5082:1: note: 'RHICreateUnorderedAccessView' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "RHICreateUnorderedAccessView is deprecated. Use FRHICommandListBase::CreateUnorderedAccessView instead.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/LightingShaders.cpp:12:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:44:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, pVolume);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:45:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume0, ComputeResource->UnorderedAccessViewRHIs[0]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:46:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume1, ComputeResource->UnorderedAccessViewRHIs[1]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:47:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume2, ComputeResource->UnorderedAccessViewRHIs[2]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:48:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume3, ComputeResource->UnorderedAccessViewRHIs[3]);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:49:3: warning: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, MinMaxValues, FVector2f(0.0, 1.0));
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, UE::Math::TVector2<float>, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:50:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, LeafNodeSize, InLeafNodeSize);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:51:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, NumberOfMips, InNumberOfMips);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:56:3: warning: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' is deprecated: SetTextureParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetTextureParameter(RHICmdList, ShaderRHI, Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:515:1: note: 'SetTextureParameter<FRHIComputeShader, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetTextureParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:57:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume0, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:58:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume1, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:59:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume2, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/Raymarcher/Module.Raymarcher.cpp:31:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Private/Rendering/OctreeShaders.cpp:6:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/Raymarcher/Public/Rendering/OctreeShaders.h:60:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, OctreeVolume3, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+62 warnings generated.
+Total time in Parallel executor: 9.14 seconds
+Total execution time: 13.06 seconds                                                     ~13s  exit:6 

--- a/logs/build5.log
+++ b/logs/build5.log
@@ -1,0 +1,105 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 8 action(s)
+------ Building 8 action(s) started ------
+[1/8] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcitem.h:29:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dctypes.h:27:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/oflog.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/logger.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config.h:42:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config/defines.h:358:5: error: 'DCMTK_ENABLE_CHARSET_CONVERSION' is not defined, evaluates to 0 [-Werror,-Wundef]
+#if DCMTK_ENABLE_CHARSET_CONVERSION == DCMTK_CHARSET_CONVERSION_ICONV ||\
+    ^
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config/defines.h:359:2: error: 'DCMTK_ENABLE_CHARSET_CONVERSION' is not defined, evaluates to 0 [-Werror,-Wundef]
+ DCMTK_ENABLE_CHARSET_CONVERSION == DCMTK_CHARSET_CONVERSION_STDLIBC_ICONV
+ ^
+7 warnings and 2 errors generated.
+[2/8] Compile Module.VolumeTextureToolkitEditor.cpp
+Total time in Parallel executor: 7.64 seconds
+Total execution time: 8.32 seconds

--- a/logs/build6.log
+++ b/logs/build6.log
@@ -1,0 +1,97 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 7 action(s)
+------ Building 7 action(s) started ------
+[1/7] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+7 warnings generated.
+[2/7] Link (lld) libUnrealEditor-VolumeTextureToolkit.so
+ld.lld: error: undefined symbol: DJDecoderRegistration::registerCodecs(E_DecompressionColorSpaceConversion, E_UIDCreation, E_PlanarConfiguration, bool, bool, bool)
+>>> referenced by VolumeTextureToolkit.cpp:49 (/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeTextureToolkit.cpp:49)
+>>>               /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp.o:(FVolumeTextureToolkitModule::StartupModule())
+>>> did you mean: DJDecoderRegistration::registerCodecs(E_DecompressionColorSpaceConversion, E_UIDCreation, E_PlanarConfiguration, bool, bool, bool, bool)
+>>> defined in: /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpeg.a(djdecode.cc.o)
+clang++: error: linker command failed with exit code 1 (use -v to see invocation)
+Total time in Parallel executor: 6.05 seconds
+Total execution time: 6.73 seconds

--- a/logs/build7.log
+++ b/logs/build7.log
@@ -1,0 +1,123 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 7 action(s)
+------ Building 7 action(s) started ------
+[1/7] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcitem.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/offile.h:30:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:118:14: error: no member named 'strlcpy' in the global namespace; did you mean simply 'strlcpy'?
+      return ::strlcpy(dst, src, siz);
+             ^~~~~~~~~
+             strlcpy
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:115:26: note: 'strlcpy' declared here
+    static inline size_t strlcpy(char *dst, const char *src, size_t siz)
+                         ^
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:144:14: error: no member named 'strlcat' in the global namespace; did you mean simply 'strlcat'?
+      return ::strlcat(dst, src, siz);
+             ^~~~~~~~~
+             strlcat
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:141:26: note: 'strlcat' declared here
+    static inline size_t strlcat(char *dst, const char *src, size_t siz)
+                         ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcitem.h:29:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dctypes.h:27:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/oflog.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/logger.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config.h:42:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config/defines.h:358:5: error: 'DCMTK_ENABLE_CHARSET_CONVERSION' is not defined, evaluates to 0 [-Werror,-Wundef]
+#if DCMTK_ENABLE_CHARSET_CONVERSION == DCMTK_CHARSET_CONVERSION_ICONV ||\
+    ^
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config/defines.h:359:2: error: 'DCMTK_ENABLE_CHARSET_CONVERSION' is not defined, evaluates to 0 [-Werror,-Wundef]
+ DCMTK_ENABLE_CHARSET_CONVERSION == DCMTK_CHARSET_CONVERSION_STDLIBC_ICONV
+ ^
+7 warnings and 4 errors generated.
+Total time in Parallel executor: 3.21 seconds
+Total execution time: 3.79 seconds

--- a/logs/build8.log
+++ b/logs/build8.log
@@ -1,0 +1,250 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 7 action(s)
+------ Building 7 action(s) started ------
+[1/7] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+7 warnings generated.
+[2/7] Link (lld) libUnrealEditor-VolumeTextureToolkit.so
+ld.lld: error: undefined symbol: std::basic_ostream<char, std::char_traits<char>>& std::__ostream_insert<char, std::char_traits<char>>(std::basic_ostream<char, std::char_traits<char>>&, char const*, long)
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decode(DcmRepresentationParameter const*, DcmPixelSequence*, DcmPolymorphOBOW&, DcmCodecParameter const*, DcmStack const&, bool&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decode(DcmRepresentationParameter const*, DcmPixelSequence*, DcmPolymorphOBOW&, DcmCodecParameter const*, DcmStack const&, bool&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced 1271 more times
+ld.lld: error: undefined symbol: std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char>>::str() const
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decode(DcmRepresentationParameter const*, DcmPixelSequence*, DcmPolymorphOBOW&, DcmCodecParameter const*, DcmStack const&, bool&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decode(DcmRepresentationParameter const*, DcmPixelSequence*, DcmPolymorphOBOW&, DcmCodecParameter const*, DcmStack const&, bool&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decode(DcmRepresentationParameter const*, DcmPixelSequence*, DcmPolymorphOBOW&, DcmCodecParameter const*, DcmStack const&, bool&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced 408 more times
+ld.lld: error: undefined symbol: std::ostream::operator<<(int)
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decode(DcmRepresentationParameter const*, DcmPixelSequence*, DcmPolymorphOBOW&, DcmCodecParameter const*, DcmStack const&, bool&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJCodecDecoder::scanJpegDataForBitDepth(unsigned char const*, unsigned int)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpeg.a
+>>> referenced 65 more times
+ld.lld: error: undefined symbol: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced 317 more times
+ld.lld: error: undefined symbol: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_replace(unsigned long, unsigned long, char const*, unsigned long)
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmPixelSequence*, DJLSCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, int, unsigned short, unsigned short, unsigned short, unsigned short)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced 321 more times
+ld.lld: error: undefined symbol: std::ostream& std::ostream::_M_insert<unsigned long>(unsigned long)
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmRepresentationParameter const*, DcmPixelSequence*, DcmCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, OFString&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::decodeFrame(DcmRepresentationParameter const*, DcmPixelSequence*, DcmCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, OFString&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by ofuuid.cc
+>>>               ofuuid.cc.o:(OFUUID::printHex(std::ostream&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 123 more times
+ld.lld: error: undefined symbol: std::basic_ios<char, std::char_traits<char>>::clear(std::_Ios_Iostate)
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJLSDecoderBase::determineDecompressedColorModel(DcmRepresentationParameter const*, DcmPixelSequence*, DcmCodecParameter const*, DcmItem*, OFString&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpls.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJCodecDecoder::decodeFrame(DcmRepresentationParameter const*, DcmPixelSequence*, DcmCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, OFString&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpeg.a
+>>> referenced by ofconapp.cc
+>>>               ofconapp.cc.o:(OFConsoleApplication::printError(char const*, int)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 96 more times
+ld.lld: error: undefined symbol: std::ostream& std::ostream::_M_insert<double>(double)
+>>> referenced by oftimer.cc
+>>>               oftimer.cc.o:(operator<<(std::ostream&, OFTimer const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftimer.cc
+>>>               oftimer.cc.o:(operator<<(std::ostream&, OFTimer const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftimer.cc
+>>>               oftimer.cc.o:(operator<<(std::ostream&, OFTimer const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 5 more times
+ld.lld: error: undefined symbol: std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char>>::basic_ostringstream()
+>>> referenced by ofuuid.cc
+>>>               ofuuid.cc.o:(OFUUID::toString(OFString&, OFUUID::E_Representation) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by threads.cc
+>>>               threads.cc.o:(dcmtk::log4cplus::thread::getCurrentThreadName()) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced by syncprims.cc
+>>>               syncprims.cc.o:(dcmtk::log4cplus::thread::impl::syncprims_throw_exception(char const*, char const*, int)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced 31 more times
+ld.lld: error: undefined symbol: strlcpy
+>>> referenced by ofstring.cc
+>>>               ofstring.cc.o:(OFString::OFString(char const*)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::combineDirAndFilename(OFFilename&, OFFilename const&, OFFilename const&, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::removeRootDirFromPathname(OFFilename&, OFFilename const&, OFFilename const&, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 33 more times
+ld.lld: error: undefined symbol: std::basic_ostream<char, std::char_traits<char>>& std::operator<<<std::char_traits<char>>(std::basic_ostream<char, std::char_traits<char>>&, char const*)
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJCodecDecoder::decodeFrame(DcmRepresentationParameter const*, DcmPixelSequence*, DcmCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, OFString&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpeg.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJCodecDecoder::decodeFrame(DcmRepresentationParameter const*, DcmPixelSequence*, DcmCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, OFString&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpeg.a
+>>> referenced by djcodecd.cc
+>>>               djcodecd.cc.o:(DJCodecDecoder::decodeFrame(DcmRepresentationParameter const*, DcmPixelSequence*, DcmCodecParameter const*, DcmItem*, unsigned int, unsigned int&, void*, unsigned int, OFString&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libdcmjpeg.a
+>>> referenced 91 more times
+ld.lld: error: undefined symbol: __isoc23_sscanf
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::setISOFormattedTime(OFString const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::setISOFormattedTime(OFString const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::setISOFormattedTime(OFString const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 35 more times
+ld.lld: error: undefined symbol: VTT for std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char>>
+>>> referenced by ofuuid.cc
+>>>               ofuuid.cc.o:(OFUUID::toString(OFString&, OFUUID::E_Representation) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by syncprims.cc
+>>>               syncprims.cc.o:(dcmtk::log4cplus::thread::impl::syncprims_throw_exception(char const*, char const*, int)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced by threads.cc
+>>>               threads.cc.o:(dcmtk::log4cplus::thread::getCurrentThreadName()) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/liboflog.a
+>>> referenced 19 more times
+ld.lld: error: undefined symbol: vtable for std::__cxx11::basic_stringbuf<char, std::char_traits<char>, std::allocator<char>>
+>>> referenced by ofuuid.cc
+>>>               ofuuid.cc.o:(OFUUID::toString(OFString&, OFUUID::E_Representation) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToMarkupString(OFString const&, OFString&, bool, OFStandard::E_MarkupMode, bool, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToOctalString(OFString const&, OFString&, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 28 more times
+>>> the vtable symbol may be undefined because the class is missing its key function (see https://lld.llvm.org/missingkeyfunction)
+ld.lld: error: undefined symbol: strlcat
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::combineDirAndFilename(OFFilename&, OFFilename const&, OFFilename const&, bool)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::getISOFormattedTime(OFString&, bool, bool, bool, bool, OFString const&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by oftime.cc
+>>>               oftime.cc.o:(OFTime::getISOFormattedTime(OFString&, bool, bool, bool, bool, OFString const&) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 5 more times
+ld.lld: error: undefined symbol: vtable for std::basic_streambuf<char, std::char_traits<char>>
+>>> referenced by ofuuid.cc
+>>>               ofuuid.cc.o:(OFUUID::toString(OFString&, OFUUID::E_Representation) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToMarkupString(OFString const&, OFString&, bool, OFStandard::E_MarkupMode, bool, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToOctalString(OFString const&, OFString&, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 28 more times
+>>> the vtable symbol may be undefined because the class is missing its key function (see https://lld.llvm.org/missingkeyfunction)
+ld.lld: error: undefined symbol: std::ostream::write(char const*, long)
+>>> referenced by ofstring.cc
+>>>               ofstring.cc.o:(operator<<(std::ostream&, OFString const&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+ld.lld: error: undefined symbol: std::locale::~locale()
+>>> referenced by ofuuid.cc
+>>>               ofuuid.cc.o:(OFUUID::toString(OFString&, OFUUID::E_Representation) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToMarkupString(OFString const&, OFString&, bool, OFStandard::E_MarkupMode, bool, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToOctalString(OFString const&, OFString&, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 35 more times
+ld.lld: error: undefined symbol: std::ios_base::~ios_base()
+>>> referenced by ofuuid.cc
+>>>               ofuuid.cc.o:(OFUUID::toString(OFString&, OFUUID::E_Representation) const) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToMarkupString(OFString const&, OFString&, bool, OFStandard::E_MarkupMode, bool, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstd.cc
+>>>               ofstd.cc.o:(OFStandard::convertToOctalString(OFString const&, OFString&, unsigned long)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 32 more times
+ld.lld: error: undefined symbol: std::istream::get(char&)
+>>> referenced by ofstring.cc
+>>>               ofstring.cc.o:(operator>>(std::istream&, OFString&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstring.cc
+>>>               ofstring.cc.o:(operator>>(std::istream&, OFString&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced by ofstring.cc
+>>>               ofstring.cc.o:(operator>>(std::istream&, OFString&)) in archive /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/lib/Linux/libofstd.a
+>>> referenced 1 more times
+ld.lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
+clang++: error: linker command failed with exit code 1 (use -v to see invocation)
+Total time in Parallel executor: 5.73 seconds
+Total execution time: 6.39 seconds

--- a/logs/build9.log
+++ b/logs/build9.log
@@ -1,0 +1,123 @@
+Setting up bundled DotNet SDK
+Running command : dotnet Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.dll TBRaymarchProjectEditor Linux Development -Project=/home/ruby/Unreal Projects/TBRaymarchProject/TBRaymarchProject.uproject
+Log file: /home/ruby/.config/Epic/UnrealBuildTool/Log.txt
+Using 'git status' to determine working set for adaptive non-unity build (/home/ruby/Unreal Projects/TBRaymarchProject).
+Building TBRaymarchProjectEditor...
+Determining max actions to execute in parallel (8 physical cores, 16 logical cores)
+  Executing up to 8 processes, one per physical core
+Using Parallel executor to run 7 action(s)
+------ Building 7 action(s) started ------
+[1/7] Compile Module.VolumeTextureToolkit.cpp
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:44:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, TextureRW);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:45:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearValue, Value);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandList>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:50:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), ClearTexture2DRW, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:104:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, ShaderRHI, Volume, VolumeRef);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:105:3: warning: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ClearValue, clearColor);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, float, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:106:3: warning: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' is deprecated: SetShaderValue with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetShaderValue(RHICmdList, ShaderRHI, ZSize, ZSizeParam);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:419:1: note: 'SetShaderValue<FRHIComputeShader *, int, FRHICommandListImmediate>' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetShaderValue with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:11:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/TextureUtilities.cpp:9:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Public/Util/UtilityShaders.h:111:3: warning: 'SetUAVParameter' is deprecated: SetUAVParameter with FRHIBatchedShaderParameters should be used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile. [-Wdeprecated-declarations]
+                SetUAVParameter(RHICmdList, RHICmdList.GetBoundComputeShader(), Volume, nullptr);
+                ^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/RenderCore/Public/ShaderParameterUtils.h:589:1: note: 'SetUAVParameter' has been explicitly marked deprecated here
+UE_DEPRECATED(5.3, "SetUAVParameter with FRHIBatchedShaderParameters should be used.")
+^
+/opt/unreal-engine-5.4.0/Engine/Source/Runtime/Core/Public/Misc/CoreMiscDefines.h:274:43: note: expanded from macro 'UE_DEPRECATED'
+#define UE_DEPRECATED(Version, Message) [[deprecated(Message " Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.")]]
+                                          ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcitem.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/offile.h:30:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:118:14: error: no member named 'strlcpy' in the global namespace; did you mean simply 'strlcpy'?
+      return ::strlcpy(dst, src, siz);
+             ^~~~~~~~~
+             strlcpy
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:115:26: note: 'strlcpy' declared here
+    static inline size_t strlcpy(char *dst, const char *src, size_t siz)
+                         ^
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:144:14: error: no member named 'strlcat' in the global namespace; did you mean simply 'strlcat'?
+      return ::strlcat(dst, src, siz);
+             ^~~~~~~~~
+             strlcat
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/ofstd/ofstd.h:141:26: note: 'strlcat' declared here
+    static inline size_t strlcat(char *dst, const char *src, size_t siz)
+                         ^
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Intermediate/Build/Linux/x64/UnrealEditor/Development/VolumeTextureToolkit/Module.VolumeTextureToolkit.cpp:13:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/Private/VolumeAsset/Loaders/DCMTKLoader.cpp:15:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcdatset.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dcitem.h:29:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/dcmdata/dctypes.h:27:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/oflog.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/logger.h:28:
+In file included from /home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config.h:42:
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config/defines.h:358:5: error: 'DCMTK_ENABLE_CHARSET_CONVERSION' is not defined, evaluates to 0 [-Werror,-Wundef]
+#if DCMTK_ENABLE_CHARSET_CONVERSION == DCMTK_CHARSET_CONVERSION_ICONV ||\
+    ^
+/home/ruby/Unreal Projects/TBRaymarchProject/Plugins/TBRaymarcherPlugin/Source/VolumeTextureToolkit/ThirdParty/dcmtk/include/dcmtk/oflog/config/defines.h:359:2: error: 'DCMTK_ENABLE_CHARSET_CONVERSION' is not defined, evaluates to 0 [-Werror,-Wundef]
+ DCMTK_ENABLE_CHARSET_CONVERSION == DCMTK_CHARSET_CONVERSION_STDLIBC_ICONV
+ ^
+7 warnings and 4 errors generated.
+Total time in Parallel executor: 3.25 seconds
+Total execution time: 3.91 seconds


### PR DESCRIPTION
## Summary

- Update `TBRaymarcherPlugin` submodule to include Linux platform support and Vulkan shader crash fixes
- Add `Documents/Notes/LinuxBuildNotes.md` — detailed guide for building DCMTK 3.6.8 from source with UE5's libc++ ABI, including workarounds for glibc C23 symbol redirects and cross-compilation limitations
- Add `logs/` directory with build troubleshooting logs preserved for reference

## Video Showcase

https://github.com/user-attachments/assets/5de5561f-c35c-4dd0-a2f6-c148a75b97dc

(Mind the quality due to compression)

## Details

### Plugin submodule update

The submodule pointer is bumped from `0042709` to `a53ca98`, pulling in 4 commits:

1. `89b2b2a` — fix(build): correct generated header include casing
2. `978cb0c` + `cff1b43` — feat(build): add linux platform support for dcmtk libraries
3. `a53ca98` — fix(vulkan): migrate shader parameter APIs to batched FRHIBatchedShaderParameters

See the plugin PR at [TBRaymarcherPlugin#21](https://github.com/tommybazar/TBRaymarcherPlugin/pull/21) for full details on the code changes.

### Linux build documentation

`LinuxBuildNotes.md` covers:

- Building DCMTK 3.6.8 with system Clang + `-stdlib=libc++` for UE5 ABI compatibility
- The glibc 2.38+ C23 redirect problem (`sscanf` → `__isoc23_sscanf`) and the `libisoc23_compat.a` shim solution
- Why cross-compilation with UE5's bundled toolchain doesn't work (DCMTK's `try_run()` for arithmetic type detection)
- CMake flags: `-DHAVE_STRLCPY=FALSE`, `-DHAVE_STRLCAT=FALSE`
- `osconfig_linux.h` configuration for `DCMTK_CHARSET_CONVERSION_OFICONV`

### Build logs

The `logs/` directory contains sequential build attempt logs (`build.log` through `build13.log`) documenting the iterative troubleshooting process. These are retained for historical reference and can help others encountering similar issues.

## Test plan

- [x] Full project build on Linux (UE 5.4, Arch Linux, Clang/libc++)
- [x] Editor launch and volume loading verified on Vulkan RHI
- [x] Windows build verification (no regressions)

> **Companion PR**: See the plugin PR at [TBRaymarcherPlugin#21](https://github.com/tommybazar/TBRaymarcherPlugin/pull/21) for the actual code changes.